### PR TITLE
docs: use full url for plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Enable flake development environments, equivalent to `nix develop`.
 To install the `nix` plugin, run:
 
 ```sh
-$ mise plugins install nix
+$ mise plugins install https://github.com/joshbode/mise-nix
 ```
 
 ## Configuration


### PR DESCRIPTION
this isn't in the registry (and probably shouldn't be since the registry is only tools) so the full url needs to be passed