### PR TITLE
Support specifying devshell and remove dependance on openssl

### DIFF
--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -1,30 +1,14 @@
-local json = require("json")
-local strings = require("vfox.strings") ---@class Strings
-
 local utils = require("utils")
 
 ---@dictionary "ignore" | "keep"
 local VARS = {
-  -- exported
+  PATH = "ignore",  -- handled in path hook
   HOME = "ignore",
   SHELL = "ignore",
   TERM = "ignore",
   TMPDIR = "ignore",
   TZ = "ignore",
 }
-
----Load environment from handle
----@param handle file*?
----@return DevEnv?
-local function get_env(handle)
-  if handle ~= nil then
-    local status, data = pcall(json.decode, handle:read("*a"))
-    handle:close()
-    return status and data or nil
-  else
-    return nil
-  end
-end
 
 function PLUGIN:MiseEnv(ctx)
   local options = ctx.options
@@ -33,73 +17,19 @@ function PLUGIN:MiseEnv(ctx)
   elseif options == true then
     options = {}
   end
+
   ---@cast options Options
-
-  if options.flake_lock == nil then
-    options.flake_lock = "flake.lock"
-  end
-
-  local project_root = utils.find_project_root("flake.nix")
-  if project_root == nil then
-    utils.log("Unable to find flake")
+  local result = utils.load_env(options)
+  if result == nil then
     return {}
-  end
-
-  local flake_file = ("%s/%s"):format(project_root, "flake.nix")
-  local lock_file = ("%s/%s"):format(project_root, options.flake_lock)
-
-  if not utils.exists(lock_file) then
-    utils.log("Lock file does not exist: %s", lock_file)
-    return {}
-  end
-
-  local hash = utils.get_hash(flake_file, lock_file)
-  if hash == nil then
-    utils.log("Unable to hash flake files")
-    return {}
-  end
-
-  local temp_dir = string.gsub(os.getenv("TMPDIR") or "/tmp", "/+$", "")
-  local filename = ("%s/mise-nix-%s"):format(temp_dir, hash)
-
-  local tag = ("%s:%s"):format(project_root, hash)
-
-  -- check if already loaded
-  if os.getenv("MISE_NIX") == tag then
-    return {}
-  end
-
-  ---@type DevEnv?
-  local env = nil
-
-  if utils.exists(filename) then
-    -- load from cache
-    env = get_env(io.open(filename))
-  end
-
-  if env == nil then
-    -- generate from nix and cache result
-    local command = ([[
-      set -o pipefail
-      nix print-dev-env \
-        --json --quiet --option warn-dirty false \
-        --reference-lock-file %q |
-        tee %q
-    ]]):format(lock_file, filename)
-    env = get_env(io.popen(command))
-
-    if env == nil then
-      utils.log("Unable to load environment")
-      return {}
-    end
   end
 
   ---@type { key: string, value: string}[]
   local exports = {
-    { key = "MISE_NIX", value = tag },
+    { key = "MISE_NIX", value = result.tag },
   }
 
-  for key, info in pairs(env.variables) do
+  for key, info in pairs(result.env.variables) do
     if VARS[key] == "ignore" then
       -- skip
     elseif info.type == "exported" then

--- a/hooks/mise_path.lua
+++ b/hooks/mise_path.lua
@@ -1,3 +1,26 @@
-function PLUGIN:MisePath(_)
-  return { }
+local utils = require("utils")
+
+local strings = require("vfox.strings") ---@class Strings
+
+function PLUGIN:MisePath(ctx)
+  local options = ctx.options
+  if options == false then
+    return {}
+  elseif options == true then
+    options = {}
+  end
+
+  ---@cast options Options
+  local result = utils.load_env(options)
+  if result == nil then
+    return {}
+  end
+
+  for key, info in pairs(result.env.variables) do
+    if key == "PATH" then
+      return strings.split(info.value, ":")
+    end
+  end
+
+  return {}
 end

--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -131,6 +131,10 @@ local function load_env(options)
     options.flake_lock = "flake.lock"
   end
 
+  if options.attribute == nil then
+    options.attribute = "default"
+  end
+
   local project_root = find_project_root("flake.nix")
   if project_root == nil then
     log("Unable to find flake")
@@ -152,8 +156,8 @@ local function load_env(options)
   end
 
   local temp_dir = string.gsub(os.getenv("TMPDIR") or "/tmp", "/+$", "")
-  local filename = ("%s/mise-nix-%s"):format(temp_dir, hash)
-  local tag = ("%s:%s"):format(project_root, hash)
+  local filename = ("%s/mise-nix-%s-%s"):format(temp_dir, hash, options.attribute)
+  local tag = ("%s:%s-%s"):format(project_root, hash, options.attribute)
 
   ---@type DevEnv?
   local env = nil
@@ -174,9 +178,9 @@ local function load_env(options)
       set -o pipefail
       nix print-dev-env \
         --json --quiet --option warn-dirty false \
-        --reference-lock-file %q |
+        --reference-lock-file %q .#%s |
         tee %q
-    ]]):format(lock_file, filename)
+    ]]):format(lock_file, options.attribute, filename)
     env = get_env(io.popen(command))
 
     if env == nil then

--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -94,7 +94,7 @@ local function get_hash(...)
   end
 
   local files = { ... }
-  local command = ("cat%s | openssl sha256"):format(string.rep(" %q", #files))
+  local command = ("cat%s | cksum -a sha256"):format(string.rep(" %q", #files))
   local handle = io.popen(command:format(table.unpack(files)))
   if handle ~= nil then
     local result = handle:read("*l")

--- a/test/foo/flake.lock
+++ b/test/foo/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730958623,
-        "narHash": "sha256-JwQZIGSYnRNOgDDoIgqKITrPVil+RMWHsZH1eE1VGN0=",
+        "lastModified": 1732238832,
+        "narHash": "sha256-sQxuJm8rHY20xq6Ah+GwIUkF95tWjGRd1X8xF+Pkk38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "85f7e662eda4fa3a995556527c87b2524b691933",
+        "rev": "8edf06bea5bcbee082df1b7369ff973b91618b8d",
         "type": "github"
       },
       "original": {

--- a/types.lua
+++ b/types.lua
@@ -14,6 +14,7 @@
 --- Nix plugin options
 ---@class Options
 ---@field flake_lock string? Optional lock file to use
+---@field attribute string? Optional attribute to use
 
 --- Nix plugin context
 ---@class Context


### PR DESCRIPTION
Hello there,

This PR contains two changes:
1. allow specifying which `devShell.<attribute>` to use
2. replace dependance on `openssl` with `coreutils` because the latter is almost guaranteed to be in path, where the former is not.