### PR TITLE
Fix `PATH` in tasks.

### DIFF
--- a/hooks/mise_env.lua
+++ b/hooks/mise_env.lua
@@ -2,7 +2,6 @@ local utils = require("utils")
 
 ---@dictionary "ignore" | "keep"
 local VARS = {
-  PATH = "ignore", -- handled in path hook
   HOME = "ignore",
   SHELL = "ignore",
   TERM = "ignore",
@@ -33,6 +32,9 @@ function PLUGIN:MiseEnv(ctx)
     ---@diagnostic disable-next-line: unnecessary-if
     if VARS[key] == "ignore" then
       -- skip
+    elseif key == "PATH" then
+      -- cache for path handler
+      exports[#exports + 1] = { key = "MISE_NIX_PATH", value = info.value }
     elseif info.type == "exported" then
       exports[#exports + 1] = { key = key, value = info.value }
     end

--- a/hooks/mise_path.lua
+++ b/hooks/mise_path.lua
@@ -11,6 +11,12 @@ function PLUGIN:MisePath(ctx)
     options = {}
   end
 
+  local path = os.getenv("MISE_NIX_PATH")
+
+  if path ~= nil then
+    return strings.split(path, ":")
+  end
+
   ---@cast options Options
   local result = utils.load_env(options)
   if result == nil then


### PR DESCRIPTION
Cache `PATH` in separate variable since checking only `MISE_NIX` prevents `load_env` from returning anything.

Fixes https://github.com/joshbode/mise-nix/issues/6.
