### PR TITLE
Don't assume `sh` is `bash`.

### DIFF
--- a/hooks/mise_path.lua
+++ b/hooks/mise_path.lua
@@ -1,7 +1,7 @@
 local utils = require("utils")
 
 ---@type Strings
-local strings = require("vfox.strings")
+local strings = require("strings")
 
 function PLUGIN:MisePath(ctx)
   local options = ctx.options


### PR DESCRIPTION
Redo of https://github.com/joshbode/mise-nix/pull/4.

Avoid using `-o pipefail` option and `[[ ... ]]` from Bash by writing the file separately instead of piping to `tee` and using the `-p` option for `mkdir`.

Fixes https://github.com/joshbode/mise-nix/issues/5.